### PR TITLE
added full game loop

### DIFF
--- a/Scenes/_levels/level_1.tscn
+++ b/Scenes/_levels/level_1.tscn
@@ -1,3 +1,9 @@
-[gd_scene format=3 uid="uid://bn56ncgudcqxy"]
+[gd_scene load_steps=2 format=3 uid="uid://bn56ncgudcqxy"]
+
+[ext_resource type="Texture2D" uid="uid://orr75x8cq8b" path="res://icon.svg" id="1_lqahr"]
 
 [node name="Level1" type="Node3D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(548, 136)
+texture = ExtResource("1_lqahr")

--- a/Scenes/_menus/game_over_screen.tscn
+++ b/Scenes/_menus/game_over_screen.tscn
@@ -1,3 +1,9 @@
-[gd_scene format=3 uid="uid://vhn5cnsocr2j"]
+[gd_scene load_steps=2 format=3 uid="uid://vhn5cnsocr2j"]
+
+[ext_resource type="Texture2D" uid="uid://orr75x8cq8b" path="res://icon.svg" id="1_w7ksk"]
 
 [node name="GameOverScreen" type="Node2D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(114, 93)
+texture = ExtResource("1_w7ksk")

--- a/Scenes/_menus/main_menu.tscn
+++ b/Scenes/_menus/main_menu.tscn
@@ -1,3 +1,77 @@
-[gd_scene format=3 uid="uid://b76f2gih7f1jo"]
+[gd_scene load_steps=4 format=3 uid="uid://b76f2gih7f1jo"]
 
-[node name="MainMenu" type="Node2D"]
+[ext_resource type="Script" path="res://Scripts/main_menu.gd" id="1_0ql8g"]
+[ext_resource type="Texture2D" uid="uid://orr75x8cq8b" path="res://icon.svg" id="2_hqxtv"]
+[ext_resource type="Theme" uid="uid://duemvjths1y6w" path="res://Themes/menu_theme.tres" id="3_xuq28"]
+
+[node name="MainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_0ql8g")
+
+[node name="TextureRect" type="TextureRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("2_hqxtv")
+
+[node name="StartButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -330.0
+offset_top = -31.0
+offset_right = -73.0
+offset_bottom = 35.0
+grow_horizontal = 0
+grow_vertical = 2
+theme = ExtResource("3_xuq28")
+text = "Start
+"
+
+[node name="OptionsButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -330.0
+offset_top = 69.0
+offset_right = -73.0
+offset_bottom = 135.0
+grow_horizontal = 0
+grow_vertical = 2
+theme = ExtResource("3_xuq28")
+text = "Options
+"
+
+[node name="ExitButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -334.0
+offset_top = 165.0
+offset_right = -77.0
+offset_bottom = 231.0
+grow_horizontal = 0
+grow_vertical = 2
+theme = ExtResource("3_xuq28")
+text = "Exit"
+
+[connection signal="button_down" from="StartButton" to="." method="_on_start_button_button_down"]
+[connection signal="button_down" from="OptionsButton" to="." method="_on_options_button_button_down"]
+[connection signal="button_down" from="ExitButton" to="." method="_on_exit_button_button_down"]

--- a/Scenes/_menus/splash_screen.tscn
+++ b/Scenes/_menus/splash_screen.tscn
@@ -1,3 +1,17 @@
-[gd_scene format=3 uid="uid://d1qulakchfluv"]
+[gd_scene load_steps=3 format=3 uid="uid://d1qulakchfluv"]
+
+[ext_resource type="Texture2D" uid="uid://orr75x8cq8b" path="res://icon.svg" id="1_4x34b"]
+[ext_resource type="Script" path="res://Scripts/splash_screen.gd" id="1_6sk1p"]
 
 [node name="SplashScreen" type="Node2D"]
+script = ExtResource("1_6sk1p")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(618, 298)
+texture = ExtResource("1_4x34b")
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 3.0
+autostart = true
+
+[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]

--- a/Scenes/_menus/win_screen.tscn
+++ b/Scenes/_menus/win_screen.tscn
@@ -1,3 +1,9 @@
-[gd_scene format=3 uid="uid://bbj8wqjbkwvar"]
+[gd_scene load_steps=2 format=3 uid="uid://bbj8wqjbkwvar"]
+
+[ext_resource type="Texture2D" uid="uid://orr75x8cq8b" path="res://icon.svg" id="1_prpw1"]
 
 [node name="WinScreen" type="Node2D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(1066, 546)
+texture = ExtResource("1_prpw1")

--- a/Scripts/AutoLoads/level_manager.gd
+++ b/Scripts/AutoLoads/level_manager.gd
@@ -48,7 +48,6 @@ func show_win_screen():
 	_change_scene(WIN_SCREEN)
 	
 func load_scene_by_path(scene):
-	print(scene)
 	if scene is String:
 		var scene_resource = load(scene)
 		if scene_resource is PackedScene:

--- a/Scripts/AutoLoads/level_manager.gd
+++ b/Scripts/AutoLoads/level_manager.gd
@@ -1,11 +1,89 @@
 extends Node
+class_name Level_Manager # note add transisions
 
+# Constants
+const CREDITS_MENU = preload("res://Scenes/_menus/credits_menu.tscn")
+const GAME_OVER_SCREEN = preload("res://Scenes/_menus/game_over_screen.tscn")
+const MAIN_MENU = preload("res://Scenes/_menus/main_menu.tscn")
+const OPTIONS_MENU = preload("res://Scenes/_menus/options_menu.tscn")
+const SPLASH_SCREEN = preload("res://Scenes/_menus/splash_screen.tscn")
+const WIN_SCREEN = preload("res://Scenes/_menus/win_screen.tscn")
+const FIRST_LEVEL = preload("res://Scenes/_levels/level_1.tscn")
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass # Replace with function body.
+# Runtime Variables
+var current_scene: Node = null
+var current_scene_packed: PackedScene = null
+var timer: float = 0
+var b_timer_active: bool = false
 
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
-	pass
+	if(Input.is_action_just_pressed("debug_win")):
+		_change_scene(WIN_SCREEN)
+		
+	if(Input.is_action_just_pressed("debug_lose")):
+		_change_scene(GAME_OVER_SCREEN)
+		
+	if b_timer_active:
+		timer += delta
+		
+func show_credits():
+	_change_scene(CREDITS_MENU)
+
+func show_game_over():
+	_change_scene(GAME_OVER_SCREEN)
+	
+func show_main_menu():
+	_change_scene(MAIN_MENU)
+	
+func show_level_1():
+	b_timer_active = true
+	timer = 0
+	_change_scene(FIRST_LEVEL)
+	
+func show_options_menu():
+	_change_scene(OPTIONS_MENU)
+	
+func show_win_screen():
+	b_timer_active = false
+	_change_scene(WIN_SCREEN)
+	
+func load_scene_by_path(scene):
+	print(scene)
+	if scene is String:
+		var scene_resource = load(scene)
+		if scene_resource is PackedScene:
+			_change_scene(scene_resource)
+		else:
+			push_error("The loaded resource is not a PackedScene.")
+	elif scene is PackedScene:
+		_change_scene(scene)
+	else:
+		push_error("Invalid scene type passed to load_scene_by_path. Expected a String path or a PackedScene.")
+
+func reload_scene():
+	call_deferred("_reload_current_scene_deferred")
+
+func _reload_current_scene_deferred():
+	var error = get_tree().reload_current_scene()
+	
+func _change_scene(packed_scene: PackedScene):
+	call_deferred("_change_scene_deffered", packed_scene)
+
+func _change_scene_deffered(packed_scene: PackedScene):
+	if packed_scene == null:
+		push_error("PackedScene is null. Cannot change scene.")
+		return
+
+	# Change the scene using the SceneTree method
+	var error = get_tree().change_scene_to_packed(packed_scene)
+
+	if error != OK:
+		push_error("Failed to change scene.")
+	else:
+		# Update the current scene references if necessary
+		current_scene_packed = packed_scene
+		current_scene = get_tree().current_scene
+		
+func stop_timer():
+	b_timer_active = false
+	timer = round(timer * pow(10.0, 2)) / pow(10.0, 2)

--- a/Scripts/main_menu.gd
+++ b/Scripts/main_menu.gd
@@ -1,0 +1,23 @@
+extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func _on_start_button_button_down() -> void:
+	LevelManager.show_level_1()
+
+
+func _on_options_button_button_down() -> void:
+	LevelManager.show_options_menu()
+
+
+func _on_exit_button_button_down() -> void:
+	get_tree().quit()

--- a/Scripts/main_menu.gd
+++ b/Scripts/main_menu.gd
@@ -1,23 +1,10 @@
 extends Control
 
-
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	pass
-
-
 func _on_start_button_button_down() -> void:
 	LevelManager.show_level_1()
 
-
 func _on_options_button_button_down() -> void:
 	LevelManager.show_options_menu()
-
 
 func _on_exit_button_button_down() -> void:
 	get_tree().quit()

--- a/Scripts/splash_screen.gd
+++ b/Scripts/splash_screen.gd
@@ -1,0 +1,15 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func _on_timer_timeout() -> void:
+	LevelManager.show_main_menu()

--- a/Scripts/splash_screen.gd
+++ b/Scripts/splash_screen.gd
@@ -1,15 +1,4 @@
 extends Node2D
 
-
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	pass
-
-
 func _on_timer_timeout() -> void:
 	LevelManager.show_main_menu()

--- a/Themes/menu_theme.tres
+++ b/Themes/menu_theme.tres
@@ -1,0 +1,4 @@
+[gd_resource type="Theme" format=3 uid="uid://duemvjths1y6w"]
+
+[resource]
+default_font_size = 42

--- a/project.godot
+++ b/project.godot
@@ -123,3 +123,13 @@ jump={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":10,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
+debug_win={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":true,"shift_pressed":true,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+debug_lose={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":true,"shift_pressed":true,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":108,"location":0,"echo":false,"script":null)
+]
+}


### PR DESCRIPTION
Added a full game loop

Splash screen loads.
Main menu and options setup and exit.
Loads level 1 placeholder
Each scene has a placeholder image to differentiate.

CTRL+ALT+SHIFT+W will auto win a level
CTRL+ALT+SHIFT+L will auto lose a level